### PR TITLE
Some heat update to the lib

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,9 +27,7 @@ allprojects {
     }
 
     tasks.withType<Test>().configureEach {
-        useJUnitPlatform {
-            excludeTags("slow")
-        }
+        useJUnitPlatform()
         testLogging {
             exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
             showStandardStreams = true
@@ -38,14 +36,14 @@ allprojects {
 }
 mindustry {
     dependency {
-        mindustry mirror "1a64344e5a"
-        arc on "v137"
+        mindustry mirror "v145"
+        arc on "v145"
     }
     client {
-        mindustry official "v137"
+        mindustry official "v145"
     }
     server {
-        mindustry official "v137"
+        mindustry official "v145"
     }
     run {
         clearOtherMods

--- a/lib/src/multicraft/IOEntry.java
+++ b/lib/src/multicraft/IOEntry.java
@@ -24,13 +24,18 @@ public class IOEntry {
     public ObjectSet<Liquid> fluidsUnique = new ObjectSet<>();
 
     public IOEntry(Seq<ItemStack> items, Seq<LiquidStack> fluids) {
-        this(items, fluids, 0f);
+        this(items, fluids, 0f, 0f);
     }
 
     public IOEntry(Seq<ItemStack> items, Seq<LiquidStack> fluids, float power) {
+        this(items, fluids, power, 0f);
+    }
+
+    public IOEntry(Seq<ItemStack> items, Seq<LiquidStack> fluids, float power, float heat) {
         this.items = items;
         this.fluids = fluids;
         this.power = power;
+        this.heat = heat;
     }
 
     public IOEntry() {
@@ -76,6 +81,7 @@ public class IOEntry {
             "items=" + items +
             "fluids=" + fluids +
             "power=" + power +
+            "heat=" + heat +
             "}";
     }
 }

--- a/lib/src/multicraft/MultiCrafter.java
+++ b/lib/src/multicraft/MultiCrafter.java
@@ -121,7 +121,7 @@ public class MultiCrafter extends Block {
      * For {@linkplain HeatConsumer},
      * maximum possible efficiency after overheat.
      */
-    public float maxEfficiency = 4f;
+    public float maxEfficiency = 0.5f;
     /**
      * For {@linkplain HeatBlock}
      */
@@ -590,7 +590,7 @@ public class MultiCrafter extends Block {
         //Heat
         if (entry.heat > 0f) {
             Table heat = new Table();
-            heat.image(Icon.terrain).color(heatColor);
+            heat.image(Icon.waves).color(heatColor);
             if (isInput) heat.left();
             else heat.right();
             Cell<Table> heatCell = t.add(heat).grow();

--- a/lib/src/multicraft/MultiCrafter.java
+++ b/lib/src/multicraft/MultiCrafter.java
@@ -121,7 +121,7 @@ public class MultiCrafter extends Block {
      * For {@linkplain HeatConsumer},
      * maximum possible efficiency after overheat.
      */
-    public float maxEfficiency = 0.5f;
+    public float maxEfficiency = 1f;
     /**
      * For {@linkplain HeatBlock}
      */

--- a/lib/src/multicraft/RecipeSelector.java
+++ b/lib/src/multicraft/RecipeSelector.java
@@ -55,7 +55,7 @@ public abstract class RecipeSelector {
             img.setColor(Pal.power);
             return img;
         } else if (outputHeat) {
-            Image img = new Image(Icon.terrain.getRegion());
+            Image img = new Image(Icon.waves.getRegion());
             img.setColor(b.heatColor);
             return img;
         }


### PR DESCRIPTION
Added heat as an option in the constructor of IOEntry.

Exemple:
```java
 new Recipe( // Input
    new IOEntry(
        Seq.with(ItemStack.with(Items.copper, 3)), //Items
        Seq.with(), //Liquids
        0f, //Power
        80f // Heat
    ), // Output
    new IOEntry(
        Seq.with(),
        Seq.with(LiquidStack.with(Liquids.water, 1))
    ), 300f // Craft Time
),
```
---

Updated to the latest Mindustry version (`v145`) for the dependencies.
Made `maxEfficiency` default to 1.
Updated heat icon (previously Terrain) to their official one (Waves)... maybe missing a notice on how much heat is required?

---
```gradle
useJUnitPlatform {
    excludeTags("slow")
}
```
Was removed to fix some error while building with latest JDK 20, Gradle 8.1.1 (required for JDK 20) and Kotlin 1.9.0-Beta (required for JDK 20), I can remove it if you want.